### PR TITLE
Markdown-It Compatibility

### DIFF
--- a/assets/javascripts/discourse/initializers/checklist.js.es6
+++ b/assets/javascripts/discourse/initializers/checklist.js.es6
@@ -26,7 +26,7 @@ export function checklistSyntax($elem, post)
     $(val).click(function(ev)
     {
       var elem = $(ev.currentTarget),
-        new_value = elem.hasClass("checked") ? "[ ]": "[*]";
+        new_value = elem.hasClass("checked") ? "[ ]": "[\\*]";
 
       elem.after('<i class="fa fa-spinner fa-spin"></i>');
       elem.hide();
@@ -35,7 +35,7 @@ export function checklistSyntax($elem, post)
       AjaxLib.ajax("/posts/" + postId, { type: 'GET', cache: false }).then(function(result)
       {
         var nth = -1, // make the first run go to index = 0
-          new_raw = result.raw.replace(/\[([\ \_\-\x\*]?)\]/ig, function(match)
+          new_raw = result.raw.replace(/\[(\s|\_|\-|\x|\\?\*)?\]/ig, function(match)
           {
             nth += 1;
             return nth === idx ? new_value : match;

--- a/assets/javascripts/discourse/initializers/checklist.js.es6
+++ b/assets/javascripts/discourse/initializers/checklist.js.es6
@@ -15,7 +15,7 @@ function initializePlugin(api)
 export function checklistSyntax($elem, post)
 {
   if (!post) { return; }
-  
+
   var boxes = $elem.find(".chcklst-box"),
     viewPost = post.getModel();
 
@@ -35,18 +35,27 @@ export function checklistSyntax($elem, post)
       AjaxLib.ajax("/posts/" + postId, { type: 'GET', cache: false }).then(function(result)
       {
         var nth = -1, // make the first run go to index = 0
-          new_raw = result.raw.replace(/\[([\ \_\-\x\*]?)\]/ig, function(match, args, offset)
+          new_raw = result.raw.replace(/\[([\ \_\-\x\*]?)\]/ig, function(match)
           {
             nth += 1;
-            return nth == idx ? new_value : match;
+            return nth === idx ? new_value : match;
           });
 
         var props = {
           raw: new_raw,
           edit_reason: 'checklist change',
-          cooked: TextLib.cook(new_raw).string
         };
-        viewPost.save(props);
+
+        if (TextLib.cookAsync) {
+          TextLib.cookAsync(new_raw).then(cooked => {
+            props.cooked = cooked.string;
+            viewPost.save(props);
+          });
+        } else {
+          props.cooked = TextLib.cook(new_raw).string;
+          viewPost.save(props);
+        }
+
       });
     });
   });
@@ -57,7 +66,7 @@ export function checklistSyntax($elem, post)
 
 export default {
   name: 'checklist',
-  initialize: function(container)
+  initialize: function()
   {
     withPluginApi('0.1', api => initializePlugin(api));
   }

--- a/assets/javascripts/lib/discourse-markdown/checklist.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/checklist.js.es6
@@ -10,7 +10,7 @@ function replaceChecklist(text) {
   text = text.replace(/\[_\]/ig, '<span class="chcklst-box fa fa-square"></span>');
   text = text.replace(/\[-\]/ig, '<span class="chcklst-box fa fa-minus-square-o"></span>');
   text = text.replace(/\[x\]/ig, '<span class="chcklst-box checked fa fa-check-square"></span>');
-  text = text.replace(/\[\*\]/ig, '<span class="chcklst-box checked fa fa-check-square-o"></span>');
+  text = text.replace(/\[\\?\*\]/ig, '<span class="chcklst-box checked fa fa-check-square-o"></span>');
   text = text.replace(/!<span class="chcklst-box (checked )?(fa fa-(square-o|square|minus-square-o|check-square|check-square-o))"><\/span>\(/ig, "![](");
   return text;
 }
@@ -111,7 +111,6 @@ function setupMarkdownIt(helper) {
 }
 
 export function setup(helper) {
-  return;
   helper.whiteList([ 'span.chcklst-stroked',
                      'span.chcklst-box fa fa-square-o',
                      'span.chcklst-box fa fa-square',

--- a/assets/javascripts/lib/discourse-markdown/checklist.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/checklist.js.es6
@@ -15,18 +15,120 @@ function replaceChecklist(text) {
   return text;
 }
 
-export function setup(helper) {
-  helper.inlineBetween({
-    between: "--",
-    emitter: function(contents) {
-      return ["span", {"class": "chcklst-stroked"}].concat(contents);
+const REGEX = /\[(\s?|_|-|x|\*)\]/ig;
+
+function getClasses(str) {
+  switch(str.toLowerCase()) {
+    case "x":
+      return "checked fa fa-check-square";
+    case "*":
+      return "checked fa fa-check-square-o";
+    case "-":
+      return "fa fa-minus-square-o";
+    case "_":
+      return "fa fa-square";
+    default:
+      return "fa fa-square-o";
+  }
+}
+
+function addCheckbox(result, content, match, state) {
+  let classes = getClasses(match[1]);
+  let token = new state.Token('check_open', 'span', 1);
+  token.attrs = [['class', `chcklst-box ${classes}`]];
+  result.push(token);
+
+  token = new state.Token('check_close', 'span', -1);
+  result.push(token);
+}
+
+function applyCheckboxes(content, state) {
+
+  let result = null,
+      pos = 0,
+      match;
+
+  while (match = REGEX.exec(content)) {
+
+    if (match.index > pos) {
+      result = result || [];
+      let token = new state.Token('text', '', 0);
+      token.content = content.slice(pos, match.index);
+      result.push(token);
     }
+
+    pos = match.index + match[0].length;
+
+    result = result || [];
+    addCheckbox(result, content, match, state);
+  }
+
+  if (result && pos < content.length) {
+    let token = new state.Token('text', '', 0);
+    token.content = content.slice(pos);
+    result.push(token);
+  }
+
+  return result;
+}
+
+function processChecklist(state) {
+  var i, j, l, tokens, token,
+        blockTokens = state.tokens,
+        nesting = 0;
+
+  for (j = 0, l = blockTokens.length; j < l; j++) {
+    if (blockTokens[j].type !== 'inline') { continue; }
+    tokens = blockTokens[j].children;
+
+    // We scan from the end, to keep position when new tags are added.
+    // Use reversed logic in links start/end match
+    for (i = tokens.length - 1; i >= 0; i--) {
+      token = tokens[i];
+
+      nesting += token.nesting;
+
+      if (token.type === 'text' && nesting === 0) {
+        let processed = applyCheckboxes(token.content, state);
+        if (processed) {
+          blockTokens[j].children = tokens = state.md.utils.arrayReplaceAt(tokens, i, processed);
+        }
+      }
+    }
+  }
+
+}
+
+
+function setupMarkdownIt(helper) {
+  helper.registerOptions((opts, siteSettings)=>{
+    opts.features['checklist'] = !!siteSettings.checklist_enabled;
   });
+
+  helper.registerPlugin(md =>{
+    md.core.ruler.push('checklist', processChecklist);
+  });
+}
+
+export function setup(helper) {
+  return;
   helper.whiteList([ 'span.chcklst-stroked',
                      'span.chcklst-box fa fa-square-o',
                      'span.chcklst-box fa fa-square',
                      'span.chcklst-box fa fa-minus-square-o',
                      'span.chcklst-box checked fa fa-check-square',
                      'span.chcklst-box checked fa fa-check-square-o' ]);
-  helper.addPreProcessor(replaceChecklist);
+
+  if (helper.markdownIt) {
+    setupMarkdownIt(helper);
+  } else {
+    helper.inlineBetween({
+      between: "--",
+      emitter: function(contents) {
+        return ["span", {"class": "chcklst-stroked"}].concat(contents);
+      }
+    });
+    helper.addPreProcessor(replaceChecklist);
+  }
+
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-plugin-checklist
 # about: Add checklist support to Discourse
-# version: 0.3.2
+# version: 0.4.0
 # authors: Matthew Wilkin
 # url: https://github.com/cpradio/discourse-plugin-checklist
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,5 +6,4 @@
 
 enabled_site_setting :checklist_enabled
 
-#register_asset 'javascripts/lib/discourse-markdown/checklist.js', :server_side
 register_asset 'stylesheets/checklist.scss'

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -9,12 +9,12 @@ describe PrettyText do
 
     it 'can properly bake boxes' do
       md = <<~MD
-        [],[ ],[_];[-]X[x]X [*] are all checkboxes
+        [],[ ],[_];[-]X[x]X [*] [\\*] are all checkboxes
         `[ ]` [x](hello) *[ ]* **[ ]** are not checkboxes
       MD
 
       html = <<~HTML
-        <p><span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square"></span>;<span class="chcklst-box fa fa-minus-square-o"></span>X<span class="chcklst-box checked fa fa-check-square"></span>X <span class="chcklst-box checked fa fa-check-square-o"></span> are all checkboxes<br>
+        <p><span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square"></span>;<span class="chcklst-box fa fa-minus-square-o"></span>X<span class="chcklst-box checked fa fa-check-square"></span>X <span class="chcklst-box checked fa fa-check-square-o"></span> <span class="chcklst-box checked fa fa-check-square-o"></span> are all checkboxes<br>
         <code>[ ]</code> <a>x</a> <em>[ ]</em> <strong>[ ]</strong> are not checkboxes</p>
       HTML
       cooked = PrettyText.cook(md)

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe PrettyText do
+
+  context 'markdown it' do
+    before do
+      SiteSetting.enable_experimental_markdown_it = true
+    end
+
+    it 'can properly bake boxes' do
+      md = <<~MD
+        [],[ ],[_];[-]X[x]X [*] are all checkboxes
+        `[ ]` [x](hello) *[ ]* **[ ]** are not checkboxes
+      MD
+
+      html = <<~HTML
+        <p><span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square-o"></span>,<span class="chcklst-box fa fa-square"></span>;<span class="chcklst-box fa fa-minus-square-o"></span>X<span class="chcklst-box checked fa fa-check-square"></span>X <span class="chcklst-box checked fa fa-check-square-o"></span> are all checkboxes<br>
+        <code>[ ]</code> <a>x</a> <em>[ ]</em> <strong>[ ]</strong> are not checkboxes</p>
+      HTML
+      cooked = PrettyText.cook(md)
+      expect(cooked).to eq(html.strip)
+    end
+  end
+end


### PR DESCRIPTION
Stop italize from applying when multiple checkboxes are checked
Remove errant return statement
Added spec for escaped checked boxes

Reference:
https://meta.discourse.org/t/commonmark-testing-started-here/65121/77?u=cpradio